### PR TITLE
fix: add escaping to handle strings and files with spaces

### DIFF
--- a/postgres-backup/sync.sh
+++ b/postgres-backup/sync.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 
-if [ ! -z "${S3_BUCKET}" ]; then
+if [ -n "${S3_BUCKET}" ]; then
   echo "Sync archives to S3"
-  s3cmd -v sync /backup s3://${S3_BUCKET}/${S3_DIR}/ --skip-existing
+  s3cmd -v sync /backup "s3://${S3_BUCKET}/${S3_DIR}/" --skip-existing
 fi
 
-if [ ! -z "${SSH_HOST}" ]; then
+if [ -n "${SSH_HOST}" ]; then
   echo "Sync archives to sftp"
   cd /backup
-  find . -name '*.psql.gz' -exec curl -v --insecure -T '{}' sftp://${SSH_USER}:${SSH_PASS}@${SSH_HOST}/${SSH_PATH}/'{}' \;
+  find . -name '*.psql.gz' -exec curl -v --insecure -T '{}' "sftp://${SSH_USER}:${SSH_PASS}@${SSH_HOST}/${SSH_PATH}/"'{}' \;
 fi


### PR DESCRIPTION
Existing code did not properly handle arguments or files with spaces in them. This was potentially dangerous when running `rm -rf $(arg)` and annoying when in say a password.

I added a bunch of escaping so that should not be an issue. I also did some minor style changes.

While I have tested that the sorting and deleting of files work, I have not tested anything that uses Postgres or SFTP.